### PR TITLE
Fix out-of-bounds brokenPixels[] write access

### DIFF
--- a/headers/MLX90641_API.h
+++ b/headers/MLX90641_API.h
@@ -46,7 +46,7 @@
         float cpAlpha;
         int16_t cpOffset;
         float emissivityEE; 
-        uint16_t brokenPixels[2];
+        uint16_t brokenPixels[3];
     } paramsMLX90641;
     
     int MLX90641_DumpEE(uint8_t slaveAddr, uint16_t *eeData);


### PR DESCRIPTION
`ExtractDeviatingPixels()` (called by `MLX90641_ExtractParameters()`) initialized 3 indices in `brokenPixels[]`, even though this array had a size of 2. Fix its size.

This commit fixes issue #2, which caused a segmentation fault in my test program.